### PR TITLE
Blog menu fixes

### DIFF
--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -1,4 +1,3 @@
-
 header .blogmenu a, #sharepanel a {
 	display: none;
 	color: #fff;
@@ -170,6 +169,14 @@ div.gallery img:active {
 	font-size: 2em;
 }
 
+#contact {
+	cursor: pointer;
+}
+
+#privacy {
+	cursor: pointer;
+}
+
 div.mobile {
 	display: none;
 }
@@ -286,11 +293,7 @@ div.mobile {
 	#contactpanel p span {
 		display: none;
 	}
-
-	#contact {
-		cursor: pointer;
-	}
-
+	
 	#back-to-top {
 		background-color: rgba(0, 0, 0, .25);
 		border-radius: 0;

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -22,6 +22,26 @@ h1.logo {
 	width: 0;
 }
 
+#contact {
+	cursor: pointer;
+}
+
+#privacy {
+	cursor: pointer;
+}
+
+#lang-en {
+	cursor: pointer;
+}
+
+#lang-nl {
+	cursor: pointer;
+}
+
+#lang-fr {
+	cursor: pointer;
+}
+
 @media only screen and (max-width: 756px) {
 	body {
 		background-color: #404040;
@@ -177,10 +197,7 @@ h1.logo {
 	#contactpanel p span {
 		display: none;
 	}
-
-	#contact {
-		cursor: pointer;
-	}
+	
 
 	#back-to-top {
 		background-color: rgba(0, 0, 0, .25);
@@ -197,26 +214,6 @@ h1.logo {
 		top: 85%;
 		transition: all 0.3s ease 0s;
 		font-size: 1.1em;
-	}
-
-	#privacy {
-		cursor: pointer;
-	}
-	
-	#lang-en {
-		cursor: pointer;
-	}
-	
-	#lang-nl {
-		cursor: pointer;
-	}
-	
-	#lang-de {
-		cursor: pointer;
-	}
-	
-	#lang-fr {
-		cursor: pointer;
 	}
 
 	/*icons*/

--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -47,8 +47,8 @@ function showMenu() {
 		element.style.display = "block";
 	}
 
-	menu.style.width = "100px";
-	menu.style.height = "276px";
+	menu.style.removeProperty("width");
+	menu.style.removeProperty("height");
 	// TODO Why did I have this again? (double clicks?) Try with onblur instead
 	window.setTimeout(setHasMenuTrue, 1000);
 	document.getElementsByClassName("filter")[0].style.display = "none";

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -68,12 +68,9 @@ class Translator {
 		}
 
 		this.load().then(() => {
-			this._options.languages.forEach((language) => {
-				this.showMenuOption(language);
-			});
-			this.hideMenuOption(this._lang);
+			this.addMenuOptions();
 		}).catch((error) => {
-			console.error(`An error occured in getting the translations: ${error}`)
+			console.error(`An error occured in loading the translations: ${error}`)
 		});
 	}
 
@@ -110,7 +107,6 @@ class Translator {
 			this._lang = lang;
 		}
 
-
 		const path = `${this._basePath}${this._lang}.json`;
 
 		return fetch(path)
@@ -140,12 +136,27 @@ class Translator {
 
 	addMenuOption(lang) {
 		const menu = document.getElementById("menu");
+		let existingMenuItem = document.getElementById(`lang-${lang}`);
+		
+		// remove existing menu item
+		if(lang === this._lang) {
+			if(existingMenuItem) {
+				menu.removeChild(existingMenuItem);
+			}
+			return;
+		}
+		
+		if(existingMenuItem) {
+			return;
+		}
+		
 		const menuItem = document.createElement("a");
 		menuItem.id = `lang-${lang}`;
 		menuItem.innerText = lang.toUpperCase();
 		menuItem.addEventListener("click", () => {
 			this.setLanguage(lang)
 		});
+				
 		menu.appendChild(menuItem);
 	}
 
@@ -153,17 +164,6 @@ class Translator {
 		this._options.languages.forEach((lang) => {
 			this.addMenuOption(lang);
 		});
-		this.hideMenuOption(this._lang);
-	}
-
-	showMenuOption(lang) {
-		const menuItem = document.getElementById(`lang-${lang}`);
-		menuItem.style.removeProperty("display");
-	}
-
-	hideMenuOption(lang) {
-		const menuItem = document.getElementById(`lang-${lang}`);
-		menuItem.style.display = "none";
 	}
 
 	localDate(day, month, year) {
@@ -214,7 +214,7 @@ class Translator {
 	get defaultConfig() {
 		return {
 			persist: true,
-			languages: ["nl", "en", "fr", "de"],
+			languages: ["nl", "en", "fr"],
 			defaultLanguage: "nl",
 		};
 	}

--- a/public/data/index.en.json
+++ b/public/data/index.en.json
@@ -1,13 +1,6 @@
 {
 	"subjects": [
 		{
-			"category": "xerbutri",
-			"abbreviation": "map",
-			"shortname": "Locations on map",
-			"realname": "Show all",
-			"description": "Show all locations on the map"
-		},
-		{
 			"category": "gebouw",
 			"abbreviation": "vbmh",
 			"shortname": "Mosquito Farm",


### PR DESCRIPTION
Removed german as supported language
Right-sizing
The right languages show when the site is loaded.
The menu items have a pointer to show they are selectable